### PR TITLE
Adding GitHub action to deploy website

### DIFF
--- a/.github/workflows/publish-to-ecr.yaml
+++ b/.github/workflows/publish-to-ecr.yaml
@@ -1,0 +1,112 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
+      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Gulp build
+        run: npm run build
+
+      - name: Build and push latest Docker image
+        env:
+          REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          cd dist
+          IMAGE_TAG=$REGISTRY/$REPOSITORY:${COMMIT_SHA}
+          echo "Building Docker image with tag $IMAGE_TAG"
+          docker build -t $IMAGE_TAG .
+
+      - name: Download Wiz CLI
+        run: curl -o wizcli https://wizcli.app.wiz.io/latest/wizcli && chmod +x wizcli
+
+      - name: Authenticate to Wiz
+        run: sudo -E ./wizcli auth
+
+      - name: Run Wiz CLI image scan
+        id: scan
+        run: sudo -E ./wizcli docker scan -i $REGISTRY/$REPOSITORY:${COMMIT_SHA} --policy ${ODLUSER}-vuln-block
+        continue-on-error: false
+        env:
+          REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+          ODLUSER: ${{ secrets.ODLUSER }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/my-github-actions-role
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+
+      - name: Push the tagged Docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          cd dist
+          IMAGE_TAG=$REGISTRY/$REPOSITORY:${COMMIT_SHA}
+          docker push $IMAGE_TAG
+
+      - name: Verify Docker image
+        env:
+          REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          REPOSITORY_URI=$REGISTRY/$REPOSITORY
+          IMAGE_TAG=$REPOSITORY_URI:${COMMIT_SHA}
+          echo "Pulling Docker image with URI: $IMAGE_TAG"
+          docker pull $IMAGE_TAG
+
+      - name: Trigger AWS App Runner
+        env:
+          AWS_REGION: "us-east-1"
+          SERVICE_ARN: ${{ secrets.APP_RUNNER_SERVICE_ARN }}
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+          ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+        run: |
+          IMAGE_URI=$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPOSITORY:$COMMIT_SHA
+          aws apprunner update-service --service-arn $SERVICE_ARN --source-configuration "ImageRepository={ImageIdentifier=\"$IMAGE_URI\",ImageRepositoryType=\"ECR\"}"
+
+      - name: Run Wiz CLI image tag
+        env:
+          ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_REGION: "us-east-1"
+          REPOSITORY: "prime-website"
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          IMAGE_URI=$ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$REPOSITORY:$COMMIT_SHA
+          sudo -E ./wizcli docker tag -i $IMAGE_URI


### PR DESCRIPTION
Adding in a github action to scan the Dockerfile for vulnerabilities. If no critical vulnerabilities, then we'll proceed with deploying the Docker image to AWS ECR. Once deployed, we update the AppRunner service to restart and point to the recently uploaded image. Finally, we'll use the WizCLI to tag the running image for image trust purposes.